### PR TITLE
feature: Generate outputs/README.md programmatically

### DIFF
--- a/generate_all_resumes.py
+++ b/generate_all_resumes.py
@@ -5,9 +5,100 @@ Generate all resume versions (ATS and Human) for all resume types
 
 import sys
 import os
+from pathlib import Path
 sys.path.append('.')
 
 from resumes.core_services import ResumeManager
+
+
+GITHUB_BASE = "https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs"
+
+RESUME_TYPE_DISPLAY = {
+    "comprehensive": ("Comprehensive", "Complete career overview showcasing the full breadth of experience across data science, software engineering, and political analytics."),
+    "data_engineering": ("Data Engineering", "Data infrastructure focus: pipelines, warehouses, ETL, Databricks, and federated architectures."),
+    "software_engineering": ("Software Engineering", "Software development expertise: full-stack systems, distributed computing, and production platforms."),
+    "gis": ("GIS & Geospatial Analysis", "Mapping and spatial analysis: PostGIS, GDAL, custom tile servers, and geospatial ML."),
+    "product": ("Product Management", "Business strategy focus: team leadership, platform development, and revenue generation."),
+    "marketing": ("Marketing Analytics", "Data-driven marketing: consumer segmentation, testing, and optimization."),
+    "data_analysis_visualization": ("Data Analysis & Visualization", "Data science specialization: ML algorithms, demographic analysis, and spatial visualization."),
+    "polling_research_redistricting": ("Political Research & Redistricting", "Research and redistricting: survey methodology, electoral prediction, and demographic modeling."),
+}
+
+COLOR_SCHEMES = [
+    "default_professional", "corporate_blue", "modern_tech", "modern_clean",
+    "satellite_imagery", "terrain_mapping", "cartographic_professional", "topographic_classic"
+]
+
+PREFERRED_COLOR = {
+    "comprehensive": "modern_tech",
+    "data_engineering": "corporate_blue",
+    "software_engineering": "satellite_imagery",
+    "gis": "terrain_mapping",
+    "product": "cartographic_professional",
+    "marketing": "modern_clean",
+    "data_analysis_visualization": "topographic_classic",
+    "polling_research_redistricting": "default_professional",
+}
+
+
+def generate_output_readme(output_dir="outputs"):
+    """Generate outputs/README.md with download links for all resume files."""
+    lines = []
+    lines.append("# Resume Portfolio - Complete Collection")
+    lines.append("")
+    lines.append("## QUICKNESS, TL/DR")
+    lines.append("")
+    lines.append("This is a selection of resumes I've made. For quick navigation, without browsing anything else, here are human-oriented, PDF formatted, longer form resumes oriented towards different roles:")
+    lines.append("")
+    for idx, (type_key, (display_name, _)) in enumerate(RESUME_TYPE_DISPLAY.items(), 1):
+        color = PREFERRED_COLOR[type_key]
+        url = f"{GITHUB_BASE}/human/{type_key}/long/{color}/pdf/dheeraj_chand_{type_key}_long_{color}.pdf"
+        lines.append(f"{idx}. **[{display_name}]({url})** - {display_name}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    total = len(RESUME_TYPE_DISPLAY) * len(COLOR_SCHEMES) * 2 * 2 * 4  # types * colors * lengths * output_types * formats
+    lines.append(f"**{total} professionally formatted resumes** systematically generated for different industries and use cases.")
+    lines.append("")
+
+    for type_key, (display_name, description) in RESUME_TYPE_DISPLAY.items():
+        lines.append(f"## {display_name}")
+        lines.append("")
+        lines.append(description)
+        lines.append("")
+
+        for length in ["long", "short"]:
+            lines.append(f"### {length.title()} Format")
+            lines.append("")
+            lines.append("| Color Scheme | PDF | DOCX | RTF | Markdown |")
+            lines.append("|--------------|-----|------|-----|----------|")
+
+            for scheme in COLOR_SCHEMES:
+                scheme_display = scheme.replace("_", " ").title()
+                fname_base = f"dheeraj_chand_{type_key}_{length}_{scheme}"
+
+                pdf_ats = f"{GITHUB_BASE}/ats/{type_key}/{length}/{scheme}/pdf/{fname_base}.pdf"
+                pdf_human = f"{GITHUB_BASE}/human/{type_key}/{length}/{scheme}/pdf/{fname_base}.pdf"
+                docx_ats = f"{GITHUB_BASE}/ats/{type_key}/{length}/{scheme}/docx/{fname_base}.docx"
+                docx_human = f"{GITHUB_BASE}/human/{type_key}/{length}/{scheme}/docx/{fname_base}.docx"
+                rtf_ats = f"{GITHUB_BASE}/ats/{type_key}/{length}/{scheme}/rtf/{fname_base}.rtf"
+                rtf_human = f"{GITHUB_BASE}/human/{type_key}/{length}/{scheme}/rtf/{fname_base}.rtf"
+                md_view = f"{GITHUB_BASE}/human/{type_key}/{length}/{scheme}/md/{fname_base}.md"
+
+                row = f"| **{scheme_display}** "
+                row += f"| [ATS]({pdf_ats}) \\| [Human]({pdf_human}) "
+                row += f"| [ATS]({docx_ats}) \\| [Human]({docx_human}) "
+                row += f"| [ATS]({rtf_ats}) \\| [Human]({rtf_human}) "
+                row += f"| [View]({md_view}) |"
+                lines.append(row)
+
+            lines.append("")
+
+    readme_path = Path(output_dir) / "README.md"
+    readme_path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"✅ Generated: {readme_path}")
+
 
 def main():
     manager = ResumeManager()
@@ -62,6 +153,9 @@ def main():
     print(f"Total generated: {total_generated}")
     print(f"Total failed: {total_failed}")
     print(f"Success rate: {(total_generated/(total_generated+total_failed)*100):.1f}%")
+
+    # Generate the output links page
+    generate_output_readme()
 
 if __name__ == "__main__":
     main()

--- a/outputs/README.md
+++ b/outputs/README.md
@@ -4,48 +4,22 @@
 
 This is a selection of resumes I've made. For quick navigation, without browsing anything else, here are human-oriented, PDF formatted, longer form resumes oriented towards different roles:
 
-1. **[Comprehensive](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/comprehensive/long/modern_tech/pdf/dheeraj_chand_comprehensive_long_modern_tech.pdf)** - Complete career overview
-2. **[Data Engineering](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_engineering/long/corporate_blue/pdf/dheeraj_chand_data_engineering_long_corporate_blue.pdf)** - Data infrastructure focus
-3. **[Software Engineering](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/long/satellite_imagery/pdf/dheeraj_chand_software_engineering_long_satellite_imagery.pdf)** - Software development expertise
-4. **[GIS & Geospatial](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/long/terrain_mapping/pdf/dheeraj_chand_gis_long_terrain_mapping.pdf)** - Mapping and spatial analysis
-5. **[Product Management](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/long/cartographic_professional/pdf/dheeraj_chand_product_long_cartographic_professional.pdf)** - Business strategy focus
-6. **[Marketing Analytics](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/long/modern_clean/pdf/dheeraj_chand_marketing_long_modern_clean.pdf)** - Data-driven marketing
-7. **[Data Analysis & Visualization](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/long/topographic_classic/pdf/dheeraj_chand_data_analysis_visualization_long_topographic_classic.pdf)** - Data science specialization
-8. **[Political Research](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/long/default_professional/pdf/dheeraj_chand_polling_research_redistricting_long_default_professional.pdf)** - Research and redistricting
+1. **[Comprehensive](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/comprehensive/long/modern_tech/pdf/dheeraj_chand_comprehensive_long_modern_tech.pdf)** - Comprehensive
+2. **[Data Engineering](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_engineering/long/corporate_blue/pdf/dheeraj_chand_data_engineering_long_corporate_blue.pdf)** - Data Engineering
+3. **[Software Engineering](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/long/satellite_imagery/pdf/dheeraj_chand_software_engineering_long_satellite_imagery.pdf)** - Software Engineering
+4. **[GIS & Geospatial Analysis](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/long/terrain_mapping/pdf/dheeraj_chand_gis_long_terrain_mapping.pdf)** - GIS & Geospatial Analysis
+5. **[Product Management](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/long/cartographic_professional/pdf/dheeraj_chand_product_long_cartographic_professional.pdf)** - Product Management
+6. **[Marketing Analytics](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/long/modern_clean/pdf/dheeraj_chand_marketing_long_modern_clean.pdf)** - Marketing Analytics
+7. **[Data Analysis & Visualization](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/long/topographic_classic/pdf/dheeraj_chand_data_analysis_visualization_long_topographic_classic.pdf)** - Data Analysis & Visualization
+8. **[Political Research & Redistricting](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/long/default_professional/pdf/dheeraj_chand_polling_research_redistricting_long_default_professional.pdf)** - Political Research & Redistricting
 
 ---
 
-
-
-**1,024 professionally formatted resumes** systematically generated for different industries and use cases.
-
-## Quick Navigation
-- [Overview](#overview)
-- [Resume Types](#resume-types)
-  - [Comprehensive](#comprehensive)
-  - [Data Engineering](#data-engineering)
-  - [Software Engineering](#software-engineering)
-  - [GIS & Geospatial Analysis](#gis)
-  - [Product Management](#product)
-  - [Marketing Analytics](#marketing)
-  - [Data Analysis & Visualization](#data-analysis-visualization)
-  - [Political Research & Redistricting](#polling-research-redistricting)
-- [Format Guide](#format-guide)
-- [Color Scheme Guide](#color-scheme-guide)
-
-## Overview
-**📊 Total Files:** 1,024 resumes organized by specialization and format
-**🎯 Output Types:** ATS-optimized and Human-readable versions
-**🎨 Color Schemes:** 8 professional color variations
-**📄 Formats:** PDF, DOCX, RTF, and Markdown
-
----
-
-## Resume Types
+**1024 professionally formatted resumes** systematically generated for different industries and use cases.
 
 ## Comprehensive
 
-Complete career overview showcasing the full breadth of experience across data science, software engineering, and political analytics. Includes all major achievements, technical skills, and project highlights. Best for senior-level positions and comprehensive career representation.
+Complete career overview showcasing the full breadth of experience across data science, software engineering, and political analytics.
 
 ### Long Format
 
@@ -75,7 +49,7 @@ Complete career overview showcasing the full breadth of experience across data s
 
 ## Data Engineering
 
-Focused on data infrastructure, ETL processes, and scalable data systems. Highlights experience with big data technologies, cloud platforms, and data pipeline optimization. Ideal for data engineering and infrastructure roles.
+Data infrastructure focus: pipelines, warehouses, ETL, Databricks, and federated architectures.
 
 ### Long Format
 
@@ -105,7 +79,7 @@ Focused on data infrastructure, ETL processes, and scalable data systems. Highli
 
 ## Software Engineering
 
-Emphasizes software development, system architecture, and technical leadership. Showcases programming expertise, code quality, and engineering best practices. Perfect for software development and technical leadership positions.
+Software development expertise: full-stack systems, distributed computing, and production platforms.
 
 ### Long Format
 
@@ -133,9 +107,9 @@ Emphasizes software development, system architecture, and technical leadership. 
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/cartographic_professional/pdf/dheeraj_chand_software_engineering_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/cartographic_professional/pdf/dheeraj_chand_software_engineering_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/cartographic_professional/docx/dheeraj_chand_software_engineering_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/cartographic_professional/docx/dheeraj_chand_software_engineering_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/cartographic_professional/rtf/dheeraj_chand_software_engineering_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/cartographic_professional/rtf/dheeraj_chand_software_engineering_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/cartographic_professional/md/dheeraj_chand_software_engineering_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/topographic_classic/pdf/dheeraj_chand_software_engineering_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/topographic_classic/pdf/dheeraj_chand_software_engineering_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/topographic_classic/docx/dheeraj_chand_software_engineering_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/topographic_classic/docx/dheeraj_chand_software_engineering_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/software_engineering/short/topographic_classic/rtf/dheeraj_chand_software_engineering_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/topographic_classic/rtf/dheeraj_chand_software_engineering_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/software_engineering/short/topographic_classic/md/dheeraj_chand_software_engineering_short_topographic_classic.md) |
 
-## Gis
+## GIS & Geospatial Analysis
 
-Specialized for geospatial analysis, mapping, and location intelligence. Features GIS software expertise, spatial analysis skills, and cartographic design. Tailored for GIS analyst and geospatial developer roles.
+Mapping and spatial analysis: PostGIS, GDAL, custom tile servers, and geospatial ML.
 
 ### Long Format
 
@@ -163,9 +137,9 @@ Specialized for geospatial analysis, mapping, and location intelligence. Feature
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/cartographic_professional/pdf/dheeraj_chand_gis_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/cartographic_professional/pdf/dheeraj_chand_gis_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/cartographic_professional/docx/dheeraj_chand_gis_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/cartographic_professional/docx/dheeraj_chand_gis_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/cartographic_professional/rtf/dheeraj_chand_gis_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/cartographic_professional/rtf/dheeraj_chand_gis_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/cartographic_professional/md/dheeraj_chand_gis_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/topographic_classic/pdf/dheeraj_chand_gis_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/topographic_classic/pdf/dheeraj_chand_gis_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/topographic_classic/docx/dheeraj_chand_gis_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/topographic_classic/docx/dheeraj_chand_gis_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/gis/short/topographic_classic/rtf/dheeraj_chand_gis_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/topographic_classic/rtf/dheeraj_chand_gis_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/gis/short/topographic_classic/md/dheeraj_chand_gis_short_topographic_classic.md) |
 
-## Product
+## Product Management
 
-Business-focused approach highlighting product strategy, user experience, and market analysis. Emphasizes product management skills, stakeholder communication, and business impact. Ideal for product management and business strategy roles.
+Business strategy focus: team leadership, platform development, and revenue generation.
 
 ### Long Format
 
@@ -193,9 +167,9 @@ Business-focused approach highlighting product strategy, user experience, and ma
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/cartographic_professional/pdf/dheeraj_chand_product_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/cartographic_professional/pdf/dheeraj_chand_product_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/cartographic_professional/docx/dheeraj_chand_product_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/cartographic_professional/docx/dheeraj_chand_product_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/cartographic_professional/rtf/dheeraj_chand_product_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/cartographic_professional/rtf/dheeraj_chand_product_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/cartographic_professional/md/dheeraj_chand_product_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/topographic_classic/pdf/dheeraj_chand_product_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/topographic_classic/pdf/dheeraj_chand_product_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/topographic_classic/docx/dheeraj_chand_product_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/topographic_classic/docx/dheeraj_chand_product_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/product/short/topographic_classic/rtf/dheeraj_chand_product_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/topographic_classic/rtf/dheeraj_chand_product_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/product/short/topographic_classic/md/dheeraj_chand_product_short_topographic_classic.md) |
 
-## Marketing
+## Marketing Analytics
 
-Marketing analytics and data-driven decision making focus. Showcases campaign analysis, customer insights, and marketing technology expertise. Perfect for marketing analytics and data-driven marketing roles.
+Data-driven marketing: consumer segmentation, testing, and optimization.
 
 ### Long Format
 
@@ -223,9 +197,9 @@ Marketing analytics and data-driven decision making focus. Showcases campaign an
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/cartographic_professional/pdf/dheeraj_chand_marketing_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/cartographic_professional/pdf/dheeraj_chand_marketing_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/cartographic_professional/docx/dheeraj_chand_marketing_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/cartographic_professional/docx/dheeraj_chand_marketing_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/cartographic_professional/rtf/dheeraj_chand_marketing_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/cartographic_professional/rtf/dheeraj_chand_marketing_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/cartographic_professional/md/dheeraj_chand_marketing_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/topographic_classic/pdf/dheeraj_chand_marketing_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/topographic_classic/pdf/dheeraj_chand_marketing_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/topographic_classic/docx/dheeraj_chand_marketing_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/topographic_classic/docx/dheeraj_chand_marketing_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/marketing/short/topographic_classic/rtf/dheeraj_chand_marketing_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/topographic_classic/rtf/dheeraj_chand_marketing_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/marketing/short/topographic_classic/md/dheeraj_chand_marketing_short_topographic_classic.md) |
 
-## Data Analysis Visualization
+## Data Analysis & Visualization
 
-Data science and visualization specialization. Features statistical analysis, machine learning, and data storytelling capabilities. Best for data scientist and analytics roles.
+Data science specialization: ML algorithms, demographic analysis, and spatial visualization.
 
 ### Long Format
 
@@ -253,9 +227,9 @@ Data science and visualization specialization. Features statistical analysis, ma
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/cartographic_professional/pdf/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/cartographic_professional/pdf/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/cartographic_professional/docx/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/cartographic_professional/docx/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/cartographic_professional/rtf/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/cartographic_professional/rtf/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/cartographic_professional/md/dheeraj_chand_data_analysis_visualization_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/topographic_classic/pdf/dheeraj_chand_data_analysis_visualization_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/topographic_classic/pdf/dheeraj_chand_data_analysis_visualization_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/topographic_classic/docx/dheeraj_chand_data_analysis_visualization_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/topographic_classic/docx/dheeraj_chand_data_analysis_visualization_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/data_analysis_visualization/short/topographic_classic/rtf/dheeraj_chand_data_analysis_visualization_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/topographic_classic/rtf/dheeraj_chand_data_analysis_visualization_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/data_analysis_visualization/short/topographic_classic/md/dheeraj_chand_data_analysis_visualization_short_topographic_classic.md) |
 
-## Polling Research Redistricting
+## Political Research & Redistricting
 
-Political research and redistricting expertise. Highlights polling methodology, demographic analysis, and political data science. Tailored for political research and policy analysis roles.
+Research and redistricting: survey methodology, electoral prediction, and demographic modeling.
 
 ### Long Format
 
@@ -282,27 +256,3 @@ Political research and redistricting expertise. Highlights polling methodology, 
 | **Terrain Mapping** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/terrain_mapping/pdf/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/terrain_mapping/pdf/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/terrain_mapping/docx/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/terrain_mapping/docx/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/terrain_mapping/rtf/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/terrain_mapping/rtf/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/terrain_mapping/md/dheeraj_chand_polling_research_redistricting_short_terrain_mapping.md) |
 | **Cartographic Professional** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/cartographic_professional/pdf/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/cartographic_professional/pdf/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/cartographic_professional/docx/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/cartographic_professional/docx/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/cartographic_professional/rtf/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/cartographic_professional/rtf/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/cartographic_professional/md/dheeraj_chand_polling_research_redistricting_short_cartographic_professional.md) |
 | **Topographic Classic** | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/topographic_classic/pdf/dheeraj_chand_polling_research_redistricting_short_topographic_classic.pdf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/topographic_classic/pdf/dheeraj_chand_polling_research_redistricting_short_topographic_classic.pdf) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/topographic_classic/docx/dheeraj_chand_polling_research_redistricting_short_topographic_classic.docx) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/topographic_classic/docx/dheeraj_chand_polling_research_redistricting_short_topographic_classic.docx) | [ATS](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/ats/polling_research_redistricting/short/topographic_classic/rtf/dheeraj_chand_polling_research_redistricting_short_topographic_classic.rtf) \| [Human](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/topographic_classic/rtf/dheeraj_chand_polling_research_redistricting_short_topographic_classic.rtf) | [View](https://raw.githubusercontent.com/dheerajchand/resume_generator/main/outputs/human/polling_research_redistricting/short/topographic_classic/md/dheeraj_chand_polling_research_redistricting_short_topographic_classic.md) |
-
----
-
-## Format Guide
-
-- **PDF**: High-quality print-ready format, optimized for ATS systems and professional printing
-- **DOCX**: Microsoft Word format for easy editing and customization
-- **RTF**: Rich Text Format for broad compatibility across different word processors
-- **Markdown**: Plain text format for web display and version control
-
-## Color Scheme Guide
-
-- **Default Professional**: Classic black and white design for maximum ATS compatibility
-- **Corporate Blue**: Professional blue theme for corporate environments
-- **Modern Tech**: Contemporary design with tech industry styling
-- **Modern Clean**: Minimalist design with clean typography
-- **Satellite Imagery**: Earth observation theme with geographic color palette
-- **Terrain Mapping**: Topographic mapping theme with elevation-based colors
-- **Cartographic Professional**: Professional cartography theme with map-inspired design
-- **Topographic Classic**: Classic topographic styling with traditional map colors
-
----
-
-*All resumes are generated from the same master data but tailored for different audiences and use cases. Each file is optimized for its specific format and audience requirements.*


### PR DESCRIPTION
## Summary

The outputs/README.md links page is now generated programmatically by `generate_all_resumes.py` after producing all 1,024 resume files. No more manual maintenance.

## Tickets

- Fixes #10
- Part-of #5

## Changes

### `generate_all_resumes.py`
- Added `generate_output_readme()` function that builds markdown tables from the same type/color/format/length matrix
- Called automatically at end of `main()`
- Includes TL;DR section with preferred color scheme per resume type
- 258 lines vs old 58K-token manually maintained file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output README automatically generated with quick links to PDF resumes and comprehensive tables showing all available formats (ATS/Human, long/short, PDF/DOCX/RTF/Markdown) organized by color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->