### PR TITLE
feature: Public download form with on-demand generation and Heroku fixes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn resume_generator_django.wsgi --log-file -
+web: gunicorn resume_generator_django.wsgi --bind 0.0.0.0:$PORT --log-file -

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ django-cors-headers>=4.0.0
 gunicorn>=20.1.0
 whitenoise>=6.0.0
 dj-database-url>=2.0.0
+psycopg2-binary>=2.9.0
 
 # Data handling and validation
 pydantic>=2.0.0

--- a/resume_generator_django/settings.py
+++ b/resume_generator_django/settings.py
@@ -21,10 +21,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-your-secret-key-here')
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    if os.environ.get('DEBUG', 'False').lower() == 'true':
+        SECRET_KEY = 'django-insecure-dev-only-key-do-not-use-in-production'
+    else:
+        raise ValueError("SECRET_KEY environment variable must be set in production")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', 'True').lower() == 'true'
+DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 

--- a/resume_generator_django/settings_production.py
+++ b/resume_generator_django/settings_production.py
@@ -14,21 +14,19 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 if not SECRET_KEY:
     raise ValueError("SECRET_KEY environment variable must be set in production")
 
-# Allowed hosts for production
-ALLOWED_HOSTS = [
-    'your-app-name.herokuapp.com',
-    'localhost',
-    '127.0.0.1',
-] + os.environ.get('ALLOWED_HOSTS', '').split(',')
+# Allowed hosts — environment variable only, no hardcoded domains
+ALLOWED_HOSTS = [h.strip() for h in os.environ.get('ALLOWED_HOSTS', '').split(',') if h.strip()]
 
 # Database configuration for production (PostgreSQL on Heroku)
 DATABASES = {
     'default': dj_database_url.config(
-        default='postgres://localhost/resume_generator',
         conn_max_age=600,
         conn_health_checks=True,
     )
 }
+
+if not os.environ.get('DATABASE_URL'):
+    raise ValueError("DATABASE_URL environment variable must be set in production")
 
 # Static files configuration for production
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
@@ -37,19 +35,16 @@ STATIC_URL = '/static/'
 # Whitenoise configuration for static files
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-# Security settings for production
+# Security settings for production — always on, not gated by DEBUG
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = 'DENY'
-SECURE_HSTS_SECONDS = 31536000 if not DEBUG else 0
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_HSTS_SECONDS = 3600  # Start with 1 hour, increase after stability confirmed
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-SECURE_HSTS_PRELOAD = True
-
-# Use HTTPS in production
-if not DEBUG:
-    SECURE_SSL_REDIRECT = True
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
+SECURE_HSTS_PRELOAD = False  # Enable after HSTS is stable
 
 # Email configuration for production
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -59,7 +54,7 @@ EMAIL_USE_TLS = True
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 
-# Logging configuration for production
+# Logging — console only, no file handler (Heroku has ephemeral filesystem)
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -68,19 +63,10 @@ LOGGING = {
             'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
             'style': '{',
         },
-        'simple': {
-            'format': '{levelname} {message}',
-            'style': '{',
-        },
     },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'formatter': 'verbose',
-        },
-        'file': {
-            'class': 'logging.FileHandler',
-            'filename': '/tmp/django.log',
             'formatter': 'verbose',
         },
     },
@@ -95,28 +81,36 @@ LOGGING = {
             'propagate': False,
         },
         'resumes': {
-            'handlers': ['console', 'file'],
+            'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,
         },
     },
 }
 
-# Cache configuration for production
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
-        'LOCATION': os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379/1'),
+# Cache — use Redis if available, fall back to database cache
+REDIS_URL = os.environ.get('REDIS_URL')
+if REDIS_URL:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+            'LOCATION': REDIS_URL,
+        }
     }
-}
+    SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+    SESSION_CACHE_ALIAS = 'default'
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'django_cache',
+        }
+    }
+    SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
-# Session configuration
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-SESSION_CACHE_ALIAS = 'default'
-
-# CORS settings for production
+# CORS settings for production — environment variable
 CORS_ALLOWED_ORIGINS = [
-    "https://your-frontend-domain.com",
+    o.strip() for o in os.environ.get('CORS_ALLOWED_ORIGINS', '').split(',') if o.strip()
 ]
 
 # File upload settings
@@ -126,14 +120,5 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 # Performance optimizations
 CONN_MAX_AGE = 600
 
-# Content Security Policy
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'")
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
-CSP_IMG_SRC = ("'self'", "data:", "https:")
-CSP_FONT_SRC = ("'self'", "https:")
-
 # Resume generation settings
 RESUME_GENERATION_TIMEOUT = 300  # 5 minutes
-MAX_CONCURRENT_GENERATIONS = 5
-ENABLE_RESUME_CACHING = True

--- a/resume_generator_django/wsgi.py
+++ b/resume_generator_django/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "resume_generator_django.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "resume_generator_django.settings_production")
 
 application = get_wsgi_application()

--- a/resumes/core_services.py
+++ b/resumes/core_services.py
@@ -123,6 +123,19 @@ class ResumeGenerator:
         self.output_type = output_type
         self.styles = self._create_styles()
         self._init_spacing_constants()
+
+    @classmethod
+    def from_data(cls, resume_data: dict, config: dict = None, color_scheme: str = 'default_professional', length_variant: str = 'long', output_type: str = 'ats'):
+        """Create a ResumeGenerator from data dicts instead of file paths."""
+        instance = object.__new__(cls)
+        instance.data = resume_data
+        instance.config = config or {}
+        instance.color_scheme = color_scheme
+        instance.length_variant = length_variant
+        instance.output_type = output_type
+        instance.styles = instance._create_styles()
+        instance._init_spacing_constants()
+        return instance
     
     def _get_contact_info(self, personal_info: dict) -> dict:
         """

--- a/resumes/templates/resumes/base.html
+++ b/resumes/templates/resumes/base.html
@@ -31,7 +31,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
-            <a class="navbar-brand" href="{% url 'resumes:dashboard' %}">
+            <a class="navbar-brand" href="{% url 'resumes:download_form' %}">
                 <i class="fas fa-file-alt me-2"></i>Resume Generator
             </a>
             
@@ -42,7 +42,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'resumes:dashboard' %}">
+                        <a class="nav-link" href="{% url 'resumes:download_form' %}">
                             <i class="fas fa-tachometer-alt me-1"></i>Dashboard
                         </a>
                     </li>

--- a/resumes/templates/resumes/download_form.html
+++ b/resumes/templates/resumes/download_form.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dheeraj Chand - Resume Download</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary: #228B22;
+            --secondary: #B8860B;
+        }
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f8f9fa;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        .hero {
+            background: linear-gradient(135deg, var(--primary), var(--secondary));
+            color: white;
+            padding: 3rem 0 2rem;
+        }
+        .form-card {
+            border: none;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+        }
+        .btn-download {
+            background: var(--primary);
+            border-color: var(--primary);
+            color: white;
+            padding: 0.75rem 2rem;
+            font-size: 1.1rem;
+        }
+        .btn-download:hover {
+            background: #1e7a1e;
+            border-color: #1e7a1e;
+            color: white;
+        }
+        footer {
+            margin-top: auto;
+            padding: 1.5rem 0;
+            background: #343a40;
+            color: #adb5bd;
+        }
+    </style>
+</head>
+<body>
+    <section class="hero">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-lg-8">
+                    <h1 class="fw-bold mb-2">Dheeraj Chand</h1>
+                    <p class="lead mb-0">Data Scientist & Software Engineer</p>
+                    <p class="mb-0 opacity-75">
+                        <a href="https://www.dheerajchand.com" class="text-white text-decoration-none">dheerajchand.com</a>
+                        &nbsp;&bull;&nbsp;
+                        <a href="https://www.linkedin.com/in/dheerajchand/" class="text-white text-decoration-none">LinkedIn</a>
+                        &nbsp;&bull;&nbsp;
+                        <a href="https://github.com/dheerajchand" class="text-white text-decoration-none">GitHub</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div class="container my-4">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="card form-card">
+                    <div class="card-body p-4">
+                        <h3 class="card-title mb-4">
+                            <i class="fas fa-download me-2"></i>Download Resume
+                        </h3>
+                        <form method="post" action="{% url 'resumes:generate_on_demand' %}">
+                            {% csrf_token %}
+
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label for="resume_type" class="form-label fw-semibold">Resume Type</label>
+                                    <select class="form-select" id="resume_type" name="resume_type" required>
+                                        {% for value, label in resume_types %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label for="length_variant" class="form-label fw-semibold">Length</label>
+                                    <select class="form-select" id="length_variant" name="length_variant" required>
+                                        {% for value, label in length_variants %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label for="color_scheme" class="form-label fw-semibold">Color Scheme</label>
+                                    <select class="form-select" id="color_scheme" name="color_scheme">
+                                        {% for value, label in color_schemes %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label for="format_type" class="form-label fw-semibold">Format</label>
+                                    <select class="form-select" id="format_type" name="format_type">
+                                        {% for value, label in formats %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+
+                                <div class="col-md-6">
+                                    <label for="output_type" class="form-label fw-semibold">Output Style</label>
+                                    <select class="form-select" id="output_type" name="output_type">
+                                        <option value="ats">ATS-Optimized</option>
+                                        <option value="human">Human-Readable</option>
+                                    </select>
+                                </div>
+
+                                <div class="col-md-6 d-flex align-items-end">
+                                    <button type="submit" class="btn btn-download w-100">
+                                        <i class="fas fa-file-download me-2"></i>Generate & Download
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="card form-card mt-4">
+                    <div class="card-body p-4">
+                        <h5 class="card-title mb-3">About These Resumes</h5>
+                        <p class="text-muted mb-2">
+                            Each resume is generated on-demand from a single master dataset, tailored to different roles and industries.
+                            The content is identical across formats — only the emphasis and selection changes.
+                        </p>
+                        <div class="row text-center mt-3">
+                            <div class="col-4">
+                                <div class="fw-bold text-primary fs-4">8</div>
+                                <small class="text-muted">Resume Types</small>
+                            </div>
+                            <div class="col-4">
+                                <div class="fw-bold text-primary fs-4">3</div>
+                                <small class="text-muted">Length Tiers</small>
+                            </div>
+                            <div class="col-4">
+                                <div class="fw-bold text-primary fs-4">8</div>
+                                <small class="text-muted">Color Schemes</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer>
+        <div class="container text-center">
+            <small>&copy; 2026 Dheeraj Chand. Built with Django and ReportLab.</small>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/resumes/urls.py
+++ b/resumes/urls.py
@@ -17,11 +17,15 @@ router.register(r'generation-jobs', views.ResumeGenerationJobViewSet, basename='
 app_name = 'resumes'
 
 urlpatterns = [
-    # Web views
-    path('', views.dashboard, name='dashboard'),
+    # Public pages — no login required
+    path('', views.download_form, name='download_form'),
+    path('download/', views.generate_on_demand, name='generate_on_demand'),
+
+    # Authenticated views
+    path('dashboard/', views.dashboard, name='dashboard'),
     path('resume/<int:resume_id>/', views.resume_detail, name='resume_detail'),
     path('resume/<int:resume_id>/download/<str:format_type>/', views.download_resume, name='download_resume'),
-    
+
     # API endpoints
     path('api/', include(router.urls)),
     path('api/generate/', views.generate_resume, name='generate_resume'),

--- a/resumes/views.py
+++ b/resumes/views.py
@@ -16,6 +16,8 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 import json
 import os
+import io
+import sys
 from pathlib import Path
 
 from .models import (
@@ -28,6 +30,145 @@ from .serializers import (
 )
 
 User = get_user_model()
+
+# Resume type display names and descriptions
+RESUME_TYPES = {
+    "comprehensive": "Comprehensive",
+    "data_engineering": "Data Engineering",
+    "software_engineering": "Software Engineering",
+    "gis": "GIS & Geospatial",
+    "product": "Product Management",
+    "marketing": "Marketing Analytics",
+    "data_analysis_visualization": "Data Analysis & Visualization",
+    "polling_research_redistricting": "Political Research & Redistricting",
+}
+
+LENGTH_VARIANTS = {
+    "long": "Long (Full Detail)",
+    "short": "Short (3-4 Pages)",
+    "brief": "Brief (1-2 Pages)",
+}
+
+COLOR_SCHEMES = [
+    "default_professional", "corporate_blue", "modern_tech", "modern_clean",
+    "satellite_imagery", "terrain_mapping", "cartographic_professional", "topographic_classic",
+]
+
+FORMAT_CONTENT_TYPES = {
+    "pdf": "application/pdf",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "rtf": "application/rtf",
+    "md": "text/markdown",
+}
+
+
+def download_form(request):
+    """Public form page for downloading resumes — no login required."""
+    context = {
+        "resume_types": RESUME_TYPES.items(),
+        "length_variants": LENGTH_VARIANTS.items(),
+        "color_schemes": [(s, s.replace("_", " ").title()) for s in COLOR_SCHEMES],
+        "formats": [("pdf", "PDF"), ("docx", "Word (DOCX)"), ("rtf", "RTF"), ("md", "Markdown")],
+    }
+    return render(request, "resumes/download_form.html", context)
+
+
+@require_http_methods(["POST"])
+def generate_on_demand(request):
+    """Generate a resume on-demand and stream it as a download — no login required.
+
+    Reads master data, builds specialized resume, applies length truncation,
+    generates the requested format in memory, and returns it.
+    """
+    resume_type = request.POST.get("resume_type", "comprehensive")
+    length_variant = request.POST.get("length_variant", "long")
+    color_scheme = request.POST.get("color_scheme", "default_professional")
+    format_type = request.POST.get("format_type", "pdf")
+    output_type = request.POST.get("output_type", "ats")
+
+    # Validate inputs
+    if resume_type not in RESUME_TYPES:
+        return HttpResponse("Invalid resume type", status=400)
+    if length_variant not in LENGTH_VARIANTS:
+        return HttpResponse("Invalid length variant", status=400)
+    if color_scheme not in COLOR_SCHEMES:
+        return HttpResponse("Invalid color scheme", status=400)
+    if format_type not in FORMAT_CONTENT_TYPES:
+        return HttpResponse("Invalid format", status=400)
+
+    # Add project root to path so master_resume_generator can be imported
+    project_root = Path(__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    from master_resume_generator import (
+        load_master_achievements,
+        create_specialized_resume,
+        create_abbreviated_resume,
+        create_brief_resume,
+    )
+    from .core_services import ResumeGenerator
+
+    # Build resume data from master
+    master_data = load_master_achievements()
+    resume_data = create_specialized_resume(master_data, resume_type, output_type)
+
+    # Apply length truncation
+    if length_variant == "short":
+        resume_data = create_abbreviated_resume(resume_data, resume_type)
+    elif length_variant == "brief":
+        resume_data = create_brief_resume(resume_data, resume_type)
+
+    # Load color scheme config
+    color_config_path = project_root / "color_schemes" / f"{color_scheme}.json"
+    config = {}
+    if color_config_path.exists():
+        with open(color_config_path, "r") as f:
+            config = json.load(f)
+
+    # Create generator from data
+    generator = ResumeGenerator.from_data(
+        resume_data=resume_data,
+        config=config,
+        color_scheme=color_scheme,
+        length_variant=length_variant,
+        output_type=output_type,
+    )
+
+    # Generate to memory buffer
+    filename = f"dheeraj_chand_{resume_type}_{length_variant}_{color_scheme}.{format_type}"
+    buffer = io.BytesIO()
+
+    if format_type == "pdf":
+        generator.generate_pdf(buffer)
+        buffer.seek(0)
+    elif format_type == "docx":
+        # python-docx can save to BytesIO
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=True) as tmp:
+            generator.generate_docx(tmp.name)
+            with open(tmp.name, "rb") as f:
+                buffer.write(f.read())
+            buffer.seek(0)
+    elif format_type == "rtf":
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".rtf", delete=True, mode="w") as tmp:
+            generator.generate_rtf(tmp.name)
+            with open(tmp.name, "rb") as f:
+                buffer.write(f.read())
+            buffer.seek(0)
+    elif format_type == "md":
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".md", delete=True, mode="w") as tmp:
+            generator.generate_markdown(tmp.name)
+            with open(tmp.name, "rb") as f:
+                buffer.write(f.read())
+            buffer.seek(0)
+
+    content_type = FORMAT_CONTENT_TYPES[format_type]
+    response = HttpResponse(buffer.read(), content_type=content_type)
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
 
 
 @login_required


### PR DESCRIPTION
## Summary

Public form page at `/` for downloading resumes on-demand. No login, no persistent storage. Fixes all 5 Heroku blockers and 8 of 11 majors from code review #19.

## Tickets

- Fixes #19

## Changes

### On-demand generation (`views.py`, `core_services.py`)
- `ResumeGenerator.from_data()` classmethod for in-memory instantiation
- `generate_on_demand` view: master data → specialized → truncated → generated → streamed
- `download_form` view: public form with type/length/color/format selectors

### Heroku fixes
- SECRET_KEY, DEBUG, WSGI, Procfile $PORT, logging, ALLOWED_HOSTS, database, Redis fallback, SSL, HSTS, psycopg2

### URL routing
- `/` → public download form
- `/download/` → on-demand generation
- `/dashboard/` → authenticated dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added on-demand resume download and generation feature with customizable options for resume type, length variant, color scheme, and output format.
  * Updated navigation to direct users to the download page.

* **Infrastructure & Security**
  * Added PostgreSQL database support.
  * Enhanced production security configuration with stricter environment variable requirements and updated default settings.
  * Modified deployment configuration for explicit network binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->